### PR TITLE
feat: modal추가, useModal(), lucide-react 설치(npm의 icon library)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.7.2",
+        "lucide-react": "^0.396.0",
         "next": "14.2.4",
         "react": "^18",
         "react-dom": "^18"
@@ -3535,6 +3536,14 @@
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.396.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.396.0.tgz",
+      "integrity": "sha512-N/zP+9vEfEYHiMWMpjwH/M5diaV0e4UFe07BpgdzaRYce5QvXi87hixf7F0Xqdr3zuX/9u7H/2D4MVXIK22O0A==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.7.2",
+    "lucide-react": "^0.396.0",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18"

--- a/src/components/AlarmModal.tsx
+++ b/src/components/AlarmModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { X } from "lucide-react";
 
+// AlarmModalProps type에 아직 미숙한 부분 있을 수 있습니다.
 type AlarmModalProps = {
   type: "disconnected" | "unsaving";
   modalSwitch: boolean;
@@ -8,6 +9,8 @@ type AlarmModalProps = {
 };
 
 export default function AlarmModal({ type }: AlarmModalProps) {
+  // modalSwitch를 prop으로 전달받으면, 아래의 modalState 일체를 삭제시키고 modalSwitch로 대체하면 됩니다.
+  // return문 가장 첫번째에 있는 modalState도 modalSwitch로 바꿔주세요.
   const [modalState, setModalState] = useState(true);
 
   const colorVariants = {
@@ -15,7 +18,8 @@ export default function AlarmModal({ type }: AlarmModalProps) {
     unsaving: "bg-[#D14343]",
   };
 
-  const handleToggle = () => {
+  // toggleModal을 prop으로 받으면, 아래의 handleExitButtonClick을 삭제하고, 해당 버튼의 onClick={toggleModal}으로 설정해주세요.
+  const handleExitButtonClick = () => {
     setModalState(!modalState);
   };
 
@@ -25,7 +29,7 @@ export default function AlarmModal({ type }: AlarmModalProps) {
         <div className="fixed inset-0 flex items-center justify-center bg-[#474D664D]">
           <div className="flex h-[215px] w-[335px] flex-col justify-center gap-4 rounded-xl bg-white p-5 shadow-xl sm:w-[395px]">
             <button
-              onClick={handleToggle}
+              onClick={handleExitButtonClick}
               className="place-self-end text-[#8F95B2]"
             >
               <X />

--- a/src/components/AlarmModal.tsx
+++ b/src/components/AlarmModal.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+
+type AlarmModalProps = {
+  type: "disconnected" | "unsaving";
+  modalSwitch: boolean;
+  toogleModal: () => {};
+};
+
+export default function AlarmModal({ type }: AlarmModalProps) {
+  const [modalState, setModalState] = useState(true);
+
+  const colorVariants = {
+    disconnected: "bg-[#4CBFA4]",
+    unsaving: "bg-[#D14343]",
+  };
+
+  const handleToggle = () => {
+    setModalState(!modalState);
+  };
+
+  return (
+    <>
+      {modalState && (
+        <div className="fixed inset-0 flex items-center justify-center bg-[#474D664D]">
+          <div className="flex h-[215px] w-[335px] flex-col justify-center gap-4 rounded-xl bg-white p-5 shadow-xl sm:w-[395px]">
+            <button
+              onClick={handleToggle}
+              className="place-self-end text-[#8F95B2]"
+            >
+              <X />
+            </button>
+            <p className="text-[16px] text-[#474D66] sm:text-[18px]">
+              {type == "disconnected" &&
+                "5분 이상 글을 쓰지 않아 접속이 끊어졌어요."}
+              {type == "unsaving" && "저장하지 않고 나가시겠어요?"}
+            </p>
+            <p className="text-[14px] text-[#8F95B2] sm:text-[16px]">
+              {type == "disconnected" &&
+                "위키 참여하기를 통해 다시 위키를 수정해 주세요."}
+              {type == "unsaving" && "작성하신 모든 내용이 사라집니다."}
+            </p>
+            <button
+              className={`mt-3 place-self-end rounded-xl p-3 px-5 py-2 text-[14px] text-white ${colorVariants[type]}`}
+            >
+              {type == "disconnected" && "확인"}
+              {type == "unsaving" && "페이지 나가기"}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ImageUploadModal.tsx
+++ b/src/components/ImageUploadModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { Camera, X } from "lucide-react";
+
+type ImageUploadModalProps = {
+  modalSwitch: boolean;
+  toggleModal: () => {};
+};
+
+export default function ImageUploadModal(
+  modalSwitch,
+  toggleModal,
+): ImageUploadModalProps {
+  // modalState를 modalSwitch로 대체해 주세요.
+  const [modalState, setModalState] = useState<boolean>(true);
+  const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(null);
+
+  const handlePreview = (e) => {
+    const insertedImageURL = URL.createObjectURL(e.target.files[0]);
+    setPreviewImageUrl(insertedImageURL);
+  };
+
+  // handleExitButtonClick을 modalSwitch로 대체해 주세요.
+  const handleExitButtonClick = () => {
+    setModalState(!modalState);
+  };
+
+  return (
+    <>
+      {modalState && (
+        <div className="fixed inset-0 flex items-center justify-center bg-[#474D664D]">
+          <div className="flex h-[338px] w-[278px] flex-col items-center justify-center gap-4 rounded-xl bg-white p-5 shadow-xl sm:h-[336px] sm:w-[395px]">
+            <button
+              onClick={handleExitButtonClick}
+              className="place-self-end text-[#8F95B2]"
+            >
+              <X />
+            </button>
+            <p className="text-[16px] font-semibold text-[#474D66] sm:text-[18px]">
+              이미지
+            </p>
+            <form className="flex w-full flex-col">
+              <label
+                htmlFor="file-input"
+                className="relative flex h-[160px] w-full cursor-pointer items-center justify-center rounded-xl bg-[#F7F7FA] text-[#C6CADA]"
+              >
+                <Camera className="animate-bounce" />
+                {previewImageUrl && (
+                  <img
+                    alt="image-preview"
+                    className="absolute h-full w-full object-contain"
+                    src={previewImageUrl}
+                  ></img>
+                )}
+              </label>
+              <input
+                id="file-input"
+                type="file"
+                className="hidden"
+                onChange={handlePreview}
+              ></input>
+              <button className="mt-3 place-self-end rounded-xl bg-[#C6CADA] p-3 px-5 py-2 text-[14px] text-white">
+                삽입하기
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ImageUploadModal.tsx
+++ b/src/components/ImageUploadModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Camera, X } from "lucide-react";
 
+// ImageUploadModalProps type에 아직 미숙한 부분 있을 수 있습니다.
 type ImageUploadModalProps = {
   modalSwitch: boolean;
   toggleModal: () => {};
@@ -10,7 +11,8 @@ export default function ImageUploadModal(
   modalSwitch,
   toggleModal,
 ): ImageUploadModalProps {
-  // modalState를 modalSwitch로 대체해 주세요.
+  // modalSwitch를 prop으로 전달받으면, 아래의 modalState 일체를 삭제시키고 modalSwitch로 대체하면 됩니다.
+  // return문 가장 첫번째에 있는 modalState도 modalSwitch로 바꿔주세요.
   const [modalState, setModalState] = useState<boolean>(true);
   const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(null);
 
@@ -19,7 +21,7 @@ export default function ImageUploadModal(
     setPreviewImageUrl(insertedImageURL);
   };
 
-  // handleExitButtonClick을 modalSwitch로 대체해 주세요.
+  // toggleModal을 prop으로 받으면, 아래의 handleExitButtonClick을 삭제하고, 해당 버튼의 onClick={toggleModal}으로 설정해주세요.
   const handleExitButtonClick = () => {
     setModalState(!modalState);
   };

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import { X, LockKeyhole } from "lucide-react";
+
+type QuizModalProps = {
+  securityQuestion: string;
+  securityAnswer: string;
+  modalSwitch: boolean;
+  toggleModal: () => {};
+};
+
+const styleVariants = {
+  basic:
+    "focus:ring-1 w-full rounded-lg bg-[#F7F7FA] p-2 px-5 py-3 text-[#8F95B2]",
+  warning: "w-full rounded-lg p-2 px-5 py-3 text-[#8F95B2] bg-[#FBEDED]",
+};
+
+export default function QuizModal({
+  securityQuestion,
+  securityAnswer,
+  modalSwitch,
+  toggleModal,
+}: QuizModalProps) {
+  // modalSwitch를 prop으로 전달받으면, 아래의 modal state 일체를 삭제시키고 modalSwitch로 대체하면 됩니다.
+  // return문 가장 첫번째에 있는 modalState도 modalSwitch로 바꿔주세요.
+  const [modalState, setModalState] = useState(true);
+  const [userAnswer, setUserAnswer] = useState<string | null>(null);
+  const [warningSwitch, setWarningSwitch] = useState<boolean>(false);
+
+  const handleSumbit = (e) => {
+    e.preventDefault();
+    if (userAnswer !== securityAnswer) {
+      setWarningSwitch(true);
+      return;
+    } else {
+      // userAnswer == securityAnswer일 때 logic을 작성해주세요.
+    }
+  };
+
+  // toggleModal을 prop으로 받으면, 아래의 handleExitButtonClick을 삭제하고, 해당 버튼의 onClick={toggleModal}으로 설정해주세요.
+  const handleExitButtonClick = () => {
+    setModalState(!modalState);
+  };
+
+  const handleInput = (e) => {
+    setUserAnswer(e.target.value);
+  };
+
+  useEffect(() => {
+    setWarningSwitch(false);
+  }, [userAnswer]);
+
+  return (
+    <>
+      {modalState && (
+        <div className="fixed inset-0 flex items-center justify-center bg-[#474D664D]">
+          <div className="flex w-[335px] flex-col rounded-lg bg-white p-5 text-black shadow-2xl backdrop-blur-md sm:min-w-[395px]">
+            <header className="flex flex-col items-center gap-3">
+              <button
+                className="mb-2 place-self-end text-[#8F95B2]"
+                onClick={handleExitButtonClick}
+              >
+                <X />
+              </button>
+              <div className="text-re rounded-full bg-[#F7F7FA] p-3 motion-reduce:animate-bounce">
+                <LockKeyhole />
+              </div>
+              <p className="mb-7 text-center text-[#8F95B2]">
+                다음 퀴즈를 맞추고 <br />
+                위키를 작성해 보세요.
+              </p>
+            </header>
+            <main>
+              <form onSubmit={handleSumbit}>
+                <label
+                  htmlFor="security-answer"
+                  className="mb-2 block text-xl font-semibold text-[#474D66]"
+                >
+                  {securityQuestion}
+                </label>
+                <input
+                  id="security-answer"
+                  value={userAnswer}
+                  onChange={handleInput}
+                  placeholder="답안을 입력해 주세요"
+                  className={
+                    warningSwitch ? styleVariants.warning : styleVariants.basic
+                  }
+                ></input>
+                {warningSwitch && (
+                  <p className="mt-3 text-[12px] text-[#D14343]">
+                    정답이 아닙니다. 다시 시도해 주세요.
+                  </p>
+                )}
+                <button className="mt-6 w-full rounded-xl bg-[#4CBFA4] p-3 text-white">
+                  확인
+                </button>
+              </form>
+            </main>
+            <footer className="mt-5 flex items-center justify-center text-center text-[12px] text-[#8F95B2]">
+              위키드는 지인들과 함께하는 즐거운 공간입니다. <br />
+              지인에게 상처를 주지 않도록 작성해 주세요.
+            </footer>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { X, LockKeyhole } from "lucide-react";
 
+// QuizModalProps type에 아직 미숙한 부분 있을 수 있습니다.
 type QuizModalProps = {
   securityQuestion: string;
   securityAnswer: string;
@@ -20,7 +21,7 @@ export default function QuizModal({
   modalSwitch,
   toggleModal,
 }: QuizModalProps) {
-  // modalSwitch를 prop으로 전달받으면, 아래의 modal state 일체를 삭제시키고 modalSwitch로 대체하면 됩니다.
+  // modalSwitch를 prop으로 전달받으면, 아래의 modalState 일체를 삭제시키고 modalSwitch로 대체하면 됩니다.
   // return문 가장 첫번째에 있는 modalState도 modalSwitch로 바꿔주세요.
   const [modalState, setModalState] = useState(true);
   const [userAnswer, setUserAnswer] = useState<string | null>(null);

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,11 @@
+import { useState } from "react"
+
+export default function useModal() {
+  const [modalSwitch, setModalSwitch] = useState(false)
+
+  function ToggleModal = () => {
+    setModalSwitch(!modalSwitch)
+  }
+
+  return [modalSwitch, ToggleModal]
+}


### PR DESCRIPTION
- [x] modal 제작
- [x] useModal() hook 제작
- [x] icon 사용을 위해 lucide-react라는 library를 설치했습니다. npm install 꼭 해주세요!
- [ ] 공동 button 컴포넌트 사용 ❌ 👉 아직 merge되지 않음 👉 merge가 완료되면 공용 컴포넌트로 대체해야함

### ① modal 파일은 총 3개이고, 사용가능한 종류는 4개입니다.

- 기존에 상의했던 것과는 좀 달라졌습니다. 👉  `AlarmModal.tsx` `QuizModal.tsx` `ImageUploadModal.tsx` 이렇게 파일이 3개이고, `AlarmModal.tsx`의 경우 `type = 'disconnected' | 'unsaving'`에 따라 2개로 사용가능하므로, 총 사용가능한 종류는 4개입니다.

### ② 페이지 내에서 실제로 modal을 사용할 경우 사용 전에 아래의 refactoring이 필요합니다. 

- `useModal()` hook을 불러와서 사용하려는 modal에 prop으로 `modalSwitch` & `toggleModal`을 꼭 넘겨주세요. (`useModal()` hook에 `type` 관련 이슈 있을 수 있습니다ㅠㅠ)
- 1️⃣ 그리고 modal component로 가서, component 내부적으로 관리하고 있는 `const  [modalState, setModalState] = useState<boolean>(true);` 를 삭제하고 prop으로 넘겨받은 modalSwitch를 사용하시면 됩니다.
- 2️⃣ 마찬가지로 `handleExitButtonClick` 을 prop으로 넘겨받은 `toggleModal`로 대체하시면 됩니다. (handleExitButtonClick)을 사용하던 button에 가서 `toggleModal`로 바꿔줘야 합니다.

### ③ icon 사용을 위해 lucide-react라는 library를 설치했습니다.

- git pull 후에 `npm install` 부탁드립니다.

### ④ 공통 button 컴포넌트가 merge가 완료되면 그 컴포넌트로 대체해야 합니다.

- 제가 하던지 사용하시는 분이 하던지 해야할 것 같습니다!

![002327 - CS](https://github.com/Codeit-Sprint-6-Part3-Team6/Wikid/assets/113002590/6ea75357-be6e-47fa-8dbe-a526c9522ecd)


