### PR TITLE
feat: AccountMenu 기능

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import Button from "./Button";
 import IconButton from "./IconButton";
 import LinkButton from "./LinkButton";
+import AccountMenu from "./accountMenu/AccountMenu";
 import NotificationList from "./notification/NotificationList";
 import useModal from "@hooks/useModal";
 import { getProfile } from "@lib/api/profileApi";
@@ -34,6 +35,7 @@ const HeaderLoggedIn = ({
 }) => {
   const router = useRouter();
   const [isOpen, handleIsOpen] = useModal();
+  const [isOpenAccountMenu, handleIsOpenAccountMenu] = useModal();
 
   const handleLogout = () => {
     Cookies.remove("accessToken");
@@ -43,13 +45,6 @@ const HeaderLoggedIn = ({
 
   return (
     <div className="flex items-center gap-[24px]">
-      <LinkButton text="임시 mypage 이동 버튼" link="/mypage" color="green" />
-      <Button
-        text="임시 로그아웃 버튼"
-        color="green"
-        type="button"
-        onClick={handleLogout}
-      />
       <div className="relative flex items-center">
         <IconButton
           src={AlarmIcon}
@@ -61,14 +56,20 @@ const HeaderLoggedIn = ({
           <NotificationList isOpen={isOpen} handleIsOpen={handleIsOpen} />
         </div>
       </div>
-      <IconButton
-        src={profileIconSrc || DefaultProfileIcon}
-        alt="프로필 아이콘"
-        className="h-[32px] w-[32px] rounded-full"
-        unoptimized={true}
-        width={32}
-        height={32}
-      />
+      <div className="relative flex items-center bg-blue-200">
+        <IconButton
+          src={profileIconSrc || DefaultProfileIcon}
+          alt="프로필 아이콘"
+          className="h-[32px] w-[32px] rounded-full"
+          unoptimized={true}
+          width={32}
+          height={32}
+          onClick={handleIsOpenAccountMenu}
+        />
+        <div className="absolute top-[10px] sm:-left-[150px] lg:-left-[150px]">
+          <AccountMenu handleLogout={handleLogout} isOpen={isOpenAccountMenu} />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/accountMenu/AccountMenu.tsx
+++ b/src/components/accountMenu/AccountMenu.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import Button from "@components/Button";
+import LinkButton from "@components/LinkButton";
+import useWindowResize from "@hooks/useWindowResize";
+import { getUserInfo } from "@lib/api/userApi";
+
+type AccountMenu = {
+  isOpen: boolean;
+  handleLogout: () => {};
+};
+
+export default function AccountMenu({ isOpen, handleLogout }) {
+  const [userCode, setUserCode] = useState();
+  const { width } = useWindowResize();
+
+  useEffect(() => {
+    const getUserCode = async () => {
+      const userInfo = await getUserInfo();
+      const code = userInfo?.profile?.code;
+      setUserCode(code);
+    };
+
+    console.log(width);
+
+    getUserCode();
+  }, []);
+
+  return (
+    <>
+      {isOpen && (
+        <div className="bg-white m-10 flex w-[130px] flex-col items-center justify-center gap-[20px] px-[29px] py-[13px] text-[14px] text-[#474D66] shadow-lg">
+          {width > 375 ? (
+            <AccounMenuDesktop
+              userCode={userCode}
+              handleLogout={handleLogout}
+            />
+          ) : (
+            <AccountMenuMobile handleLogout={handleLogout} />
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+type AccounMenuDesktopProps = {
+  userCode: string;
+  handleLogout: () => {};
+};
+
+const AccounMenuDesktop = ({ userCode, handleLogout }) => {
+  return (
+    <>
+      <LinkButton text="계정 설정" link="/mypage" color="white" />
+      <LinkButton text="내 위키" link={`/wiki/${userCode}`} color="white" />
+      <Button
+        color="white"
+        text="로그아웃"
+        className="border-none"
+        type="button"
+        onClick={handleLogout}
+      />
+    </>
+  );
+};
+
+type AccountMenuMobileProps = {
+  handleLogout: () => {};
+};
+
+const AccountMenuMobile = ({ handleLogout }) => {
+  return (
+    <>
+      <LinkButton
+        text="위키 목록"
+        link="/wikilist"
+        color="white"
+        className="w-full"
+      />
+      <LinkButton
+        text="자유게시판"
+        link="/boards"
+        color="white"
+        className="w-full"
+      />
+      <Button
+        color="white"
+        text="알림"
+        type="button"
+        className="border-none"
+        onClick={handleLogout}
+      />
+      <LinkButton text="마이 페이지" link="/mypage" color="white" />
+    </>
+  );
+};

--- a/src/hooks/useWindowResize.ts
+++ b/src/hooks/useWindowResize.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from "react";
+
+export default function useWindowResize() {
+  const [windowSize, setWindowSize] = useState({ width: 0 });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+      });
+    }
+    window.addEventListener("resize", handleResize);
+
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  });
+
+  return windowSize;
+}


### PR DESCRIPTION
# 1. Todo

- [x] Account Menu 구현
- [ ] width < 375 이하에서 div를 벗어나는거 해결하기 (위치조정)
- [ ] `<Button />` component text색깔 조정 안되는 문제 해결하기  👉 버튼의 default가 초록색인데 원하는 색깔(`#474D66`)이 안먹힘 .. 이 색깔은 메인페이지에서도 적용이 안되고 있는 색깔임

# 2. 구현 스크린샷

## width > 375

![002464 - CS](https://github.com/Codeit-Sprint-6-Part3-Team6/Wikid/assets/113002590/c51ae2c3-0ec8-4400-a28d-d9c3963f6514)

## width < 375

![002465 - CS](https://github.com/Codeit-Sprint-6-Part3-Team6/Wikid/assets/113002590/9f601123-d25e-4b88-9b8e-0c515a255fd1)